### PR TITLE
Use var to declare router the first time it is used

### DIFF
--- a/src/joint.dia.link.js
+++ b/src/joint.dia.link.js
@@ -208,7 +208,7 @@ joint.dia.Link = joint.dia.Cell.extend({
 
         // getter
         if (name === undefined) {
-            router = this.get('router');
+            var router = this.get('router');
             if (!router) {
                 if (this.get('manhattan')) return { name: 'orthogonal' }; // backwards compatibility
                 return null;


### PR DESCRIPTION
This fixes an error I'm getting: `ReferenceError: assignment to undeclared variable router`